### PR TITLE
Compatability with the Algernons Terrain Sampler mod

### DIFF
--- a/Farseer/Server/FarRegionGen.cs
+++ b/Farseer/Server/FarRegionGen.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Vintagestory.API.Common;
@@ -8,7 +9,7 @@ namespace Farseer.Server;
 
 public delegate void FarRegionGeneratedDelegate(long regionIdx, FarRegionHeightmap generatedHeightmap);
 
-public class FarRegionGen
+public class FarRegionGen : IDisposable
 {
   class InProgressRegion
   {
@@ -38,20 +39,39 @@ public class FarRegionGen
   private readonly int chunksInRegionColumn;
   private readonly int chunksInRegionArea;
 
+  private readonly TerrainSamplerAdapter terrainSamplerAdapter;
+
   public FarRegionGen(FarseerModSystem modSystem, ICoreServerAPI sapi)
   {
     this.modSystem = modSystem;
     this.sapi = sapi;
-    sapi.Event.ChunkColumnLoaded += OnChunkColumnLoaded;
-    sapi.Event.RegisterGameTickListener((_) => LoadNextFarChunksInQueue(), 8004);
 
     chunksInRegionColumn = sapi.WorldManager.RegionSize / sapi.WorldManager.ChunkSize;
     chunksInRegionArea = chunksInRegionColumn * chunksInRegionColumn;
+
+    terrainSamplerAdapter = TerrainSamplerAdapter.TryCreate(modSystem, sapi);
+
+    if (terrainSamplerAdapter != null)
+    {
+      terrainSamplerAdapter.RegionGenerated += (idx, heightMap) => FarRegionGenerated?.Invoke(idx, heightMap);
+    }
+    else
+    {
+      sapi.Event.ChunkColumnLoaded += this.OnChunkColumnLoaded;
+      _ = sapi.Event.RegisterGameTickListener((_) => this.LoadNextFarChunksInQueue(), 8004);
+    }
   }
 
   public void StartGeneratingRegion(long regionIdx)
   {
-    if (regionGenerationQueue.Any(r => r.RegionIdx == regionIdx)) return;
+    if (terrainSamplerAdapter != null)
+    {
+      terrainSamplerAdapter.StartGeneratingRegion(regionIdx);
+      return;
+    }
+
+    if (regionGenerationQueue.Any(r => r.RegionIdx == regionIdx))
+      return;
 
     var regionPos = sapi.WorldManager.MapRegionPosFromIndex2D(regionIdx);
     var chunkStartX = regionPos.X * chunksInRegionColumn;
@@ -270,6 +290,13 @@ public class FarRegionGen
         modSystem.Mod.Logger.Notification("All done!");
       }
     }
+  }
+
+  public void Dispose()
+  {
+    terrainSamplerAdapter?.Dispose();
+    if (terrainSamplerAdapter == null)
+      sapi.Event.ChunkColumnLoaded -= this.OnChunkColumnLoaded;
   }
 
   public void GenerateDummyData(long regionIdx)

--- a/Farseer/Server/FarRegionProvider.cs
+++ b/Farseer/Server/FarRegionProvider.cs
@@ -70,7 +70,7 @@ public class FarRegionProvider : IDisposable
   {
     db.InsertRegionHeightmap(regionIdx, generatedHeightmap);
     var newRegionData = CreateDataObject(regionIdx, generatedHeightmap);
-    inMemoryRegionCache.Add(regionIdx, newRegionData);
+    inMemoryRegionCache[regionIdx] = newRegionData;
     RegionReady?.Invoke(newRegionData);
   }
 
@@ -123,6 +123,7 @@ public class FarRegionProvider : IDisposable
 
   public void Dispose()
   {
+    generator?.Dispose();
     db?.Dispose();
     GC.SuppressFinalize(this);
   }

--- a/Farseer/Server/TerrainSamplerAdapter.cs
+++ b/Farseer/Server/TerrainSamplerAdapter.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace Farseer.Server;
+
+public class TerrainSamplerAdapter : IDisposable
+{
+  private readonly FarseerModSystem modSystem;
+  private readonly ICoreServerAPI sapi;
+
+  private readonly Func<int, int, int> sampleHeightDelegate;
+
+  private readonly int chunksInRegionColumn;
+  private readonly ConcurrentDictionary<long, byte> asyncSamplingInProgress = new();
+  private readonly SemaphoreSlim samplerSemaphore;
+  private readonly CancellationTokenSource cancelSamplingTokenSource = new();
+  private volatile bool disposed;
+
+  public event FarRegionGeneratedDelegate RegionGenerated;
+
+  private TerrainSamplerAdapter(
+    FarseerModSystem modSystem,
+    ICoreServerAPI serverAPI,
+    Func<int, int, int> sampleHeightDelegate,
+    int maxConcurrentSampling)
+  {
+    this.modSystem = modSystem;
+    this.sapi = serverAPI;
+    this.sampleHeightDelegate = sampleHeightDelegate;
+    this.samplerSemaphore = new SemaphoreSlim(maxConcurrentSampling, maxConcurrentSampling);
+
+    this.chunksInRegionColumn = serverAPI.WorldManager.RegionSize / serverAPI.WorldManager.ChunkSize;
+  }
+
+  /// <summary>
+  /// Creates the Terrain Sampler if the terrain sampler mod is enabled
+  /// </summary>
+  public static TerrainSamplerAdapter TryCreate(FarseerModSystem modSystem, ICoreServerAPI sapi)
+  {
+    try
+    {
+      foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+      {
+        Type modType = assembly.GetType("AlgernonsTerrainSampler.TerrainSamplerMod");
+        if (modType == null)
+          continue;
+
+        PropertyInfo instanceProperty = modType.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
+        MethodInfo getHeightMethod = modType.GetMethod("GetBlockColumnHeight", BindingFlags.Public | BindingFlags.Instance,
+          null, [typeof(int), typeof(int)], null);
+        if (instanceProperty == null || getHeightMethod == null)
+          break;
+
+        object instance = instanceProperty.GetValue(null);
+        int sampleHeight(int blockX, int blockZ) => (int)getHeightMethod.Invoke(instance, [blockX, blockZ]);
+
+        int maxConcurrentSampling = Math.Clamp(Environment.ProcessorCount - 4, 1, 4);
+        return new TerrainSamplerAdapter(modSystem, sapi, sampleHeight, maxConcurrentSampling);
+      }
+    }
+    catch (Exception) { }
+
+    return null;
+  }
+
+  public void StartGeneratingRegion(long regionIdx)
+  {
+    if (this.disposed || !this.asyncSamplingInProgress.TryAdd(regionIdx, 0))
+      return;
+
+    Vec3i regionPos = this.sapi.WorldManager.MapRegionPosFromIndex2D(regionIdx);
+    int chunkStartX = regionPos.X * this.chunksInRegionColumn;
+    int chunkStartZ = regionPos.Z * this.chunksInRegionColumn;
+    int gridSize = this.modSystem.Server.Config.HeightmapGridSize;
+    int regionSize = this.sapi.WorldManager.RegionSize;
+    int chunkSize = this.sapi.WorldManager.ChunkSize;
+    int seaLevel = this.sapi.World.SeaLevel;
+
+    CancellationToken cancelSamplingToken = this.cancelSamplingTokenSource.Token;
+
+    _ = Task.Run(async () =>
+    {
+      try
+      {
+        await this.samplerSemaphore.WaitAsync(cancelSamplingToken);
+      }
+      catch (OperationCanceledException)
+      {
+        _ = this.asyncSamplingInProgress.TryRemove(regionIdx, out _);
+        return;
+      }
+      catch (ObjectDisposedException)
+      {
+        _ = this.asyncSamplingInProgress.TryRemove(regionIdx, out _);
+        return;
+      }
+
+      try
+      {
+        var heightmap = new FarRegionHeightmap
+        {
+          GridSize = gridSize,
+          Points = new int[gridSize * gridSize],
+        };
+
+        float cellSize = regionSize / (float)gridSize;
+
+        for (int z = 0; z < gridSize; z++)
+        {
+          for (int x = 0; x < gridSize; x++)
+          {
+            if (cancelSamplingToken.IsCancellationRequested)
+            {
+              _ = this.asyncSamplingInProgress.TryRemove(regionIdx, out _);
+              return;
+            }
+
+            int blockX = (chunkStartX * chunkSize) + (int)(x * cellSize);
+            int blockZ = (chunkStartZ * chunkSize) + (int)(z * cellSize);
+
+            int sampledHeight = this.sampleHeightDelegate(blockX, blockZ);
+            heightmap.Points[(z * gridSize) + x] = GameMath.Max(sampledHeight, seaLevel);
+          }
+        }
+
+        if (!this.disposed)
+        {
+          this.sapi.Event.EnqueueMainThreadTask(() =>
+          {
+            _ = this.asyncSamplingInProgress.TryRemove(regionIdx, out _);
+            if (!this.disposed)
+              RegionGenerated?.Invoke(regionIdx, heightmap);
+          }, "farseer-terrain-sample");
+        }
+      }
+      finally
+      {
+        try
+        {
+          _ = this.samplerSemaphore.Release();
+        }
+        catch (ObjectDisposedException) { }
+      }
+    });
+  }
+
+  public void Dispose()
+  {
+    if (this.disposed)
+      return;
+
+    this.disposed = true;
+    this.cancelSamplingTokenSource.Cancel();
+    this.cancelSamplingTokenSource.Dispose();
+    this.samplerSemaphore.Dispose();
+  }
+}


### PR DESCRIPTION
When the terrain sampler mod is enabled, height samples come from the mod, rather than peeked chunks. This speeds Farseer up by a lot. 
Instead of generating the terrain for the whole chunk then selecting samples from that terrain, the samples are simply calculated individually.