### PR TITLE
Feature/1.22

### DIFF
--- a/Farseer/Farseer.csproj
+++ b/Farseer/Farseer.csproj
@@ -1,50 +1,52 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\Mods\mod</OutputPath>
+    <GamePath>C:\Users\$(USERNAME)\AppData\Roaming\Vintagestory</GamePath>
+    <GamePath Condition="Exists('$(VINTAGE_STORY)')">$(VINTAGE_STORY)</GamePath>
   </PropertyGroup>
 
   <ItemGroup>
     <Reference Include="VintagestoryAPI">
-      <HintPath>$(VINTAGE_STORY)/VintagestoryAPI.dll</HintPath>
+      <HintPath>$(GamePath)\VintagestoryAPI.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="VSSurvivalMod">
-      <HintPath>$(VINTAGE_STORY)/Mods/VSSurvivalMod.dll</HintPath>
+      <HintPath>$(GamePath)\Mods\VSSurvivalMod.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VSEssentials">
-      <HintPath>$(VINTAGE_STORY)/Mods/VSEssentials.dll</HintPath>
+      <HintPath>$(GamePath)\Mods\VSEssentials.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VSCreativeMod">
-      <HintPath>$(VINTAGE_STORY)/Mods/VSCreativeMod.dll</HintPath>
+      <HintPath>$(GamePath)\Mods\VSCreativeMod.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>$(VINTAGE_STORY)/Lib/Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(GamePath)\Lib\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="0Harmony">
-      <HintPath>$(VINTAGE_STORY)/Lib/0Harmony.dll</HintPath>
+      <HintPath>$(GamePath)\Lib\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VintagestoryLib">
-      <HintPath>$(VINTAGE_STORY)/VintagestoryLib.dll</HintPath>
+      <HintPath>$(GamePath)\VintagestoryLib.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>$(VINTAGE_STORY)/Lib/protobuf-net.dll</HintPath>
+      <HintPath>$(GamePath)\Lib\protobuf-net.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="cairo-sharp">
-      <HintPath>$(VINTAGE_STORY)/Lib/cairo-sharp.dll</HintPath>
+      <HintPath>$(GamePath)\Lib\cairo-sharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Sqlite">
-      <HintPath>$(VINTAGE_STORY)/Lib/Microsoft.Data.Sqlite.dll</HintPath>
+      <HintPath>$(GamePath)\Lib\Microsoft.Data.Sqlite.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Farseer/Server/FarseerServer.cs
+++ b/Farseer/Server/FarseerServer.cs
@@ -104,7 +104,7 @@ public class FarseerServer : IDisposable
     foreach (var player in modPlayers.Values)
     {
       var oldPos = player.LastPos;
-      var newPos = player.ServerPlayer.Entity.ServerPos.XYZInt;
+      var newPos = player.ServerPlayer.Entity.Pos.XYZInt;
 
       if (oldPos != null)
       {

--- a/Farseer/modinfo.json
+++ b/Farseer/modinfo.json
@@ -6,9 +6,9 @@
     "Badgerson"
   ],
   "description": "Draws silhouettes of the terrain outside of your view distance",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "dependencies": {
-    "game": "1.21.0"
+    "game": "1.22.0"
   },
   "side": "Universal",
   "requiredOnClient": true,

--- a/ZZCakeBuild/CakeBuild.csproj
+++ b/ZZCakeBuild/CakeBuild.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="3.0.0" />
-    <PackageReference Include="Cake.Json" Version="7.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Cake.Frosting" Version="6.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/ZZCakeBuild/CakeBuild.csproj
+++ b/ZZCakeBuild/CakeBuild.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
+    <GamePath>C:\Users\$(USERNAME)\AppData\Roaming\Vintagestory</GamePath>
+    <GamePath Condition="Exists('$(VINTAGE_STORY)')">$(VINTAGE_STORY)</GamePath>
   </PropertyGroup>
   
   <ItemGroup>
@@ -13,7 +15,7 @@
   
   <ItemGroup>
     <Reference Include="VintagestoryAPI">
-      <HintPath>$(VINTAGE_STORY)/VintagestoryAPI.dll</HintPath>
+      <HintPath>$(GamePath)\VintagestoryAPI.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/ZZCakeBuild/Program.cs
+++ b/ZZCakeBuild/Program.cs
@@ -7,7 +7,6 @@ using Cake.Common.Tools.DotNet.Clean;
 using Cake.Common.Tools.DotNet.Publish;
 using Cake.Core;
 using Cake.Frosting;
-using Cake.Json;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Vintagestory.API.Common;
@@ -37,7 +36,7 @@ public class BuildContext : FrostingContext
     {
         BuildConfiguration = context.Argument("configuration", "Release");
         SkipJsonValidation = context.Argument("skipJsonValidation", false);
-        var modInfo = context.DeserializeJsonFromFile<ModInfo>($"../{ProjectName}/modinfo.json");
+        var modInfo = JsonConvert.DeserializeObject<ModInfo>(File.ReadAllText($"../{ProjectName}/modinfo.json"));
         Version = modInfo.Version;
         Name = modInfo.ModID;
     }


### PR DESCRIPTION
This pull request updates both the main mod project and the build tooling for compatibility with newer frameworks and the latest version of the Vintage Story game. It also improves how the game path is resolved, updates dependencies, and fixes a minor code issue. The most important changes are grouped below:

**Framework and Compatibility Updates:**

* Updated the target framework for both `Farseer` and `ZZCakeBuild` projects from `net8.0` to `net10.0` to ensure compatibility with future .NET releases. [[1]](diffhunk://#diff-b3b67545a4ab8ba4859f96801faa033ace6cbacdbedaed5da3bde792685e3489L4-R49) [[2]](diffhunk://#diff-3a39d863df47402aab4ae8e692eaa709535483a579f5d24ca7231c0df9646990L4-R18)
* Increased the required Vintage Story game version in `modinfo.json` from `1.21.0` to `1.22.0` and bumped the mod version to `1.3.4`.

**Game Path and Reference Improvements:**

* Changed all project references to use a new `GamePath` property instead of `VINTAGE_STORY`, allowing for a default path and an override if the environment variable is set. This affects both `.csproj` files and ensures more reliable DLL resolution. [[1]](diffhunk://#diff-b3b67545a4ab8ba4859f96801faa033ace6cbacdbedaed5da3bde792685e3489L4-R49) [[2]](diffhunk://#diff-3a39d863df47402aab4ae8e692eaa709535483a579f5d24ca7231c0df9646990L4-R18)

**Build Tooling and Dependency Updates:**

* Updated NuGet package dependencies in `ZZCakeBuild` to newer versions, removed the unused `Cake.Json` package, added `NuGet.Protocol`, and updated usage to `Newtonsoft.Json` for JSON deserialization. [[1]](diffhunk://#diff-3a39d863df47402aab4ae8e692eaa709535483a579f5d24ca7231c0df9646990L4-R18) [[2]](diffhunk://#diff-15d1928d07c5016070aaba58515459c108740083a07bad1b56dcca35811e53d2L10) [[3]](diffhunk://#diff-15d1928d07c5016070aaba58515459c108740083a07bad1b56dcca35811e53d2L40-R39)

**Code Fixes:**

* Fixed a property access in `FarseerServer.cs` to use `Entity.Pos.XYZInt` instead of the deprecated `Entity.ServerPos.XYZInt`.